### PR TITLE
Enable automatic decompression (CURLOPT_ACCEPT_ENCODING)

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -46,6 +46,7 @@ http* http_new(void)
     return NULL;
   }
 
+  curl_easy_setopt(h->curl, CURLOPT_ACCEPT_ENCODING, "");
   curl_easy_setopt(h->curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
 
 #if DEBUG_CURL == 1


### PR DESCRIPTION
This PR enables libcurl automatic decompression, allowing megatools to handle gzipped responses. Fixes #178.