### PR TITLE
Output progress rate and cap frequency

### DIFF
--- a/lib/mega.c
+++ b/lib/mega.c
@@ -22,6 +22,7 @@
 #include "http.h"
 #include "sjson.h"
 #include "alloc.h"
+#include "tools.h"
 
 #include <gio/gio.h>
 #include <glib/gstdio.h>
@@ -44,6 +45,8 @@ DEFINE_CLEANUP_FUNCTION_NULL(BIGNUM*, BN_free)
 #define gc_bn_free CLEANUP(BN_free)
 
 #define CACHE_FORMAT_VERSION 3
+#define PROGRESS_FREQUENCY ((gint64)2e6)
+#define PROGRESS_ONESEC ((gint64)1e6)
 
 gint mega_debug = 0;
 
@@ -126,6 +129,8 @@ struct _mega_sesssion
   gpointer status_userdata;
 
   gint64 last_refresh;
+  gint64 last_progress;
+  guint64 last_progress_bytes;
   gboolean create_preview;
 };
 
@@ -2903,10 +2908,20 @@ static gchar* create_preview(mega_session* s, const gchar* local_path, const guc
 
 static gboolean progress_generic(goffset total, goffset now, mega_session* s)
 {
+  const gint64 timenow = g_get_monotonic_time();
+  if (s->last_progress && s->last_progress + PROGRESS_FREQUENCY > timenow)
+    return TRUE;
+
   init_status(s, MEGA_STATUS_PROGRESS);
   s->status_data.progress.total = total;
   s->status_data.progress.done = now;
-  if (send_status(s)) 
+  s->status_data.progress.last = s->last_progress_bytes;
+  s->status_data.progress.span = timenow - s->last_progress;
+
+  s->last_progress = timenow;
+  s->last_progress_bytes = now;
+
+  if (send_status(s))
       return FALSE;
 
   return TRUE;
@@ -4140,6 +4155,37 @@ gboolean mega_session_register_verify(mega_session* s, mega_reg_state* state, co
   //[{"a":"up","privk":"KSUujv7KB8QYL2At2sWeMPi2DQd_e09FwbR2RwileC9NxYw0MxFTKFj7Yxha__borDmBUacxaWXRCnMnAmMlsyWc8zw_ml9tysYHOsL4cQEzpBJtCCIrhnRjwnQk8JUVK--5fyQRS6G2RiOVdeFjkKQyifmXgBsiAlhHKhzSY0VD6ruR9htGfDsgImim_S-MzuWaHQN8TJkBkSZRAgXy6O2tUh0Bk4aEp8NaEV0GHdV7ec1S1jbR9FzwKB7cNkKxk2nd7wRS9rnl_QPz4MTv84dS6qHxahT0ebU5njC2_IkFLxuVlloyO2UTPRPHa9JHaPa3R2BrEmb-eWMmsZ5icNwJl8PLzuc9YlSI09-IR5rHZLm2uW-V05GI1IHIjw9LGzqli6WL7tzlMVhHrsq-xj70iXjVvOXJ3XhwbbW99S8O-3sQ2gG36fSHUcg0WMSD-8KiD-DhmhfqX8iqg-2YDfXrsYUNhq_VHJF83Zm0itPdRIkgUtBR9MFdASSPe_8uxlEBsCATTHNGIWbH0wiKRo2tEqbUTZCJjXhAyTyMhdjbSdS1ARKNr12YHkLKi12uhIJRO73VJGmjZD8De59cPduGihLGt3ipIKVIxsm-Xy6f9p29BtDHE1go_yacqbW1n8d1anN8WhmG8Q_1PwY1h-opagpd-Nf0geFti_3PI8dY75NPAuDyknv0kgn8OZ4ItzO10-4H3_GgLa5m8zb6usk-eeVCo4lkC4Z2YHHlY4YLRIL7rWC0m_kFcsyvVi1-PVNJ8GauLt9PYmW9hj20yJLwCYkEVSQyM4Yxgh55hSa3La3FnUt3Nls_ImOdcDWtYpB0UKJSKN_IYH4NlD60VwvFUifJndRB_JlJGvqzR4s","pubk":"B_9lGyG4ImN-3idVOARGr6dk-4Nn6VwVYxCTSk1nDvXztCNQ-eFwxIJoS3ykODSH_AjHhst_Loj_erSgX-AUOBAjkh5rQuriA4ciT76tIh_IarC5Yf2Zey8Ao_gLPgaqrLTIWPxDhSAmCLd3pa3X9weAuGK_7eiVxmXU4tK_5j7dyn949C4OMNhxp9vRgZqaOzcjouwKm8xH9nWqXTR7F2WKW2BcXxeBkRnFVJz6cd5IqmJENabhDH1-UDf9eCW7GeD2MHU8xnbJk2fXqnru35nxz9OG6VvVDMzrS6dtQU8mC7xnIut_N6eyMRWsHpm8N1bSxHgz1XWCodnOBHFIJSoJAAUR"}] -> ["-a1DHeWfguY"]
 
   return TRUE;
+}
+
+// }}}
+// {{{ mega_status_output_progress
+
+void mega_status_output_progress (const gchar* file, const mega_status_data *data)
+{
+  if (data->progress.total <= 0)
+    return;
+
+  {
+    gc_free gchar* done_str = g_format_size_full(
+      data->progress.done, G_FORMAT_SIZE_IEC_UNITS | G_FORMAT_SIZE_LONG_FORMAT);
+    gc_free gchar* total_str = g_format_size_full(
+      data->progress.total, G_FORMAT_SIZE_IEC_UNITS);
+    const guint64 rate = (data->progress.done - data->progress.last) * 1e6 / data->progress.span;
+    gc_free gchar* rate_str = g_format_size(rate);
+    const double percentage = (double)(data->progress.done * 100 * 1000 / data->progress.total) / 1000.0;
+
+    g_print(
+      ESC_WHITE "%s"
+      ESC_NORMAL ": " ESC_YELLOW "%.2f%%"
+      ESC_NORMAL " - " ESC_GREEN "%s"
+      ESC_BLUE " of %s"
+      ESC_NORMAL " (%s/s)" ESC_CLREOL "\r",
+      file,
+      percentage,
+      done_str,
+      total_str,
+      rate_str);
+  }
 }
 
 // }}}

--- a/lib/mega.h
+++ b/lib/mega.h
@@ -59,6 +59,8 @@ struct _mega_status_data
     {
       guint64 total;
       guint64 done;
+      guint64 last;
+      gint64 span;
     } progress;
 
     struct
@@ -181,5 +183,7 @@ gchar*              mega_node_get_path_dup          (mega_node* n);
 
 gboolean            mega_session_register           (mega_session* s, const gchar* email, const gchar* password, const gchar* name, mega_reg_state** state, GError** err);
 gboolean            mega_session_register_verify    (mega_session* s, mega_reg_state* state, const gchar* signup_key, GError** err);
+
+void                mega_status_output_progress     (const gchar* file, const mega_status_data *data);
 
 #endif

--- a/lib/tools.h
+++ b/lib/tools.h
@@ -41,12 +41,16 @@ extern gboolean tool_allow_unknown_options;
 #define ESC_CLREOL ""
 #define ESC_WHITE ""
 #define ESC_GREEN ""
+#define ESC_YELLOW ""
+#define ESC_BLUE ""
 #define ESC_GRAY ""
 #define ESC_NORMAL ""
 #else
 #define ESC_CLREOL "\x1b[0K"
 #define ESC_WHITE "\x1b[37;1m"
 #define ESC_GREEN "\x1b[32;1m"
+#define ESC_YELLOW "\x1b[33;1m"
+#define ESC_BLUE "\x1b[34;1m"
 #define ESC_GRAY "\x1b[30;1m"
 #define ESC_NORMAL "\x1b[0m"
 #endif

--- a/tools/copy.c
+++ b/tools/copy.c
@@ -39,16 +39,7 @@ static GOptionEntry entries[] =
 static gboolean status_callback(mega_status_data* data, gpointer userdata)
 {
   if (!opt_noprogress && data->type == MEGA_STATUS_PROGRESS)
-  {
-    gchar* done_str = g_format_size_full(data->progress.done, G_FORMAT_SIZE_IEC_UNITS);
-    gchar* total_str = g_format_size_full(data->progress.total, G_FORMAT_SIZE_IEC_UNITS);
-
-    if (data->progress.total > 0)
-      g_print("  " ESC_GREEN "%" G_GUINT64_FORMAT "%%" ESC_NORMAL " - " ESC_GREEN "%s" ESC_NORMAL " of %s" ESC_CLREOL "\r", 100 * data->progress.done / data->progress.total, done_str, total_str);
-
-    g_free(done_str);
-    g_free(total_str);
-  }
+    mega_status_output_progress("copying...", data);
 
   return FALSE;
 }

--- a/tools/dl.c
+++ b/tools/dl.c
@@ -53,13 +53,7 @@ static gboolean status_callback(mega_status_data* data, gpointer userdata)
   }
 
   if (!opt_noprogress && data->type == MEGA_STATUS_PROGRESS)
-  {
-    gc_free gchar* done_str = g_format_size_full(data->progress.done, G_FORMAT_SIZE_IEC_UNITS);
-    gc_free gchar* total_str = g_format_size_full(data->progress.total, G_FORMAT_SIZE_IEC_UNITS);
-
-    if (data->progress.total > 0)
-      g_print(ESC_WHITE "%s" ESC_NORMAL ": " ESC_GREEN "%" G_GUINT64_FORMAT "%%" ESC_NORMAL " - " ESC_GREEN "%s" ESC_NORMAL " of %s" ESC_CLREOL "\r", cur_file, 100 * data->progress.done / data->progress.total, done_str, total_str);
-  }
+    mega_status_output_progress(cur_file, data);
 
   return FALSE;
 }

--- a/tools/get.c
+++ b/tools/get.c
@@ -46,13 +46,7 @@ static gboolean status_callback(mega_status_data* data, gpointer userdata)
   }
 
   if (!opt_noprogress && data->type == MEGA_STATUS_PROGRESS)
-  {
-    gc_free gchar* done_str = g_format_size_full(data->progress.done, G_FORMAT_SIZE_IEC_UNITS);
-    gc_free gchar* total_str = g_format_size_full(data->progress.total, G_FORMAT_SIZE_IEC_UNITS);
-
-    if (data->progress.total > 0)
-      g_print(ESC_WHITE "%s" ESC_NORMAL ": " ESC_GREEN "%" G_GINT64_FORMAT  "%%" ESC_NORMAL " - " ESC_GREEN "%s" ESC_NORMAL " of %s" ESC_CLREOL "\r", cur_file, 100 * data->progress.done / data->progress.total, done_str, total_str);
-  }
+    mega_status_output_progress(cur_file, data);
 
   return FALSE;
 }

--- a/tools/put.c
+++ b/tools/put.c
@@ -39,13 +39,7 @@ static gboolean status_callback(mega_status_data* data, gpointer userdata)
   }
 
   if (!opt_noprogress && data->type == MEGA_STATUS_PROGRESS)
-  {
-    gc_free gchar* done_str = g_format_size_full(data->progress.done, G_FORMAT_SIZE_IEC_UNITS);
-    gc_free gchar* total_str = g_format_size_full(data->progress.total, G_FORMAT_SIZE_IEC_UNITS);
-
-    if (data->progress.total > 0)
-      g_print(ESC_WHITE "%s" ESC_NORMAL ": " ESC_GREEN "%" G_GUINT64_FORMAT "%%" ESC_NORMAL " - " ESC_GREEN "%s" ESC_NORMAL " of %s" ESC_CLREOL "\r", cur_file, 100 * data->progress.done / data->progress.total, done_str, total_str);
-  }
+    mega_status_output_progress(cur_file, data);
 
   return FALSE;
 }


### PR DESCRIPTION
The progress output can be very excessive, outputting every couple of milliseconds, which is bad when you use megatools e.g. over a slow-ish ssh connection. Thus cap the output frequency at at most once every 2 seconds.

Also add more colors and output the transfer rate (since the last progress update), which in turn addresses https://github.com/megous/megatools/issues/189