### PR TITLE
http: define CURL_AT_LEAST_VERSION if it's not defined

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -23,6 +23,13 @@
 #include <string.h>
 #include <time.h>
 
+// curlver.h: this macro was added in May 14, 2015
+#ifndef CURL_AT_LEAST_VERSION
+#define CURL_VERSION_BITS(x,y,z) ((x)<<16|(y)<<8|z)
+#define CURL_AT_LEAST_VERSION(x,y,z) \
+  (LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(x, y, z))
+#endif
+
 #define DEBUG_CURL 0
 
 struct _http


### PR DESCRIPTION
I get this error:

    lib/http.c: In function ‘http_new’:
    lib/http.c:49:26: error: missing binary operator before token "("
    make: *** [all] Error 2

I'm using curl 7.22.0 from Ubuntu Precise, this:
https://github.com/gridcoin/Gridcoin-Research/blob/master/src/curlver.h

Current curlver.h:
https://github.com/curl/curl/blob/master/include/curl/curlver.h

The CURL_AT_LEAST_VERSION macro is fairly recent (was added in May 2015) ..
https://github.com/curl/curl/commit/39b9bf60d13ff7cb62a6a031c210d27a32113c4f