### PR TITLE
Resume download in cURL

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -363,7 +363,7 @@ again:
   return res;
 }
 
-gboolean http_post_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, GError** err)
+gboolean http_post_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, GError** err, goffset resume_from)
 {
   struct curl_slist* headers = NULL;
   glong http_status = 0;
@@ -380,6 +380,9 @@ gboolean http_post_stream_download(http* h, const gchar* url, http_data_fn write
   // setup post headers and url
   curl_easy_setopt(h->curl, CURLOPT_POST, 1L);
   curl_easy_setopt(h->curl, CURLOPT_URL, url);
+
+  // resume download
+  curl_easy_setopt(h->curl, CURLOPT_RESUME_FROM_LARGE, resume_from);
 
   // request is empty
   curl_easy_setopt(h->curl, CURLOPT_POSTFIELDSIZE, 0);

--- a/lib/http.h
+++ b/lib/http.h
@@ -50,7 +50,7 @@ void http_set_progress_callback(http* h, http_progress_fn cb, gpointer data);
 
 GString* http_post(http* h, const gchar* url, const gchar* body, gssize body_len, GError** err);
 GString* http_post_stream_upload(http* h, const gchar* url, goffset len, http_data_fn read_cb, gpointer user_data, GError** err);
-gboolean http_post_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, GError** err);
+gboolean http_post_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, GError** err, goffset resume_from);
 
 void http_free(http* h);
 


### PR DESCRIPTION
I need some help with this PR. I use `g_file_append_to` to open
the existing file, then set `CURLOPT_RESUME_FROM`, but download
resume still does not work

See Issue #7
