### PR TITLE
Initial quick'n'dirty implementation for UL/DL speed limits

### DIFF
--- a/README
+++ b/README
@@ -164,6 +164,7 @@ Contributors
 ============
 
 - RealDolos <dolos@cock.li>
+- Tom Maneiro <tomman@tsdx.net.ve>
 
 
 Support and bug reports

--- a/lib/http.c
+++ b/lib/http.c
@@ -133,6 +133,12 @@ static int curl_progress(http* h, double dltotal, double dlnow, double ultotal, 
   return 0;
 }
 
+void http_set_speed(http* h, gint max_ul, gint max_dl)
+{
+  curl_easy_setopt(h->curl, CURLOPT_MAX_SEND_SPEED_LARGE, (curl_off_t)max_ul * 1024);
+  curl_easy_setopt(h->curl, CURLOPT_MAX_RECV_SPEED_LARGE, (curl_off_t)max_dl * 1024);
+}
+
 void http_set_progress_callback(http* h, http_progress_fn cb, gpointer data)
 {
   if (cb)

--- a/lib/http.h
+++ b/lib/http.h
@@ -47,6 +47,7 @@ void http_set_content_length(http* h, goffset len);
 void http_no_expect(http* h);
 void http_set_header(http* h, const gchar* name, const gchar* value);
 void http_set_progress_callback(http* h, http_progress_fn cb, gpointer data);
+void http_set_speed(http* h, gint max_ul, gint max_dl);
 
 GString* http_post(http* h, const gchar* url, const gchar* body, gssize body_len, GError** err);
 GString* http_post_stream_upload(http* h, const gchar* url, goffset len, http_data_fn read_cb, gpointer user_data, GError** err);

--- a/lib/mega.c
+++ b/lib/mega.c
@@ -105,6 +105,9 @@ struct _rsa_key {
 struct _mega_sesssion 
 {
   http* http;
+  // UL/DL speed settings
+  gint max_ul;
+  gint max_dl;
 
   gint id;
   gchar* sid;
@@ -1933,7 +1936,7 @@ GQuark mega_error_quark(void)
 
 // {{{ mega_session_new
 
-mega_session* mega_session_new(void)
+mega_session* mega_session_new()
 {
   mega_session* s = g_new0(mega_session, 1);
 
@@ -1946,6 +1949,12 @@ mega_session* mega_session_new(void)
   s->share_keys = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
 
   return s;
+}
+
+void mega_session_set_speed(mega_session* s, gint ul, gint dl)
+{
+  s->max_ul = ul;
+  s->max_dl = dl;
 }
 
 // }}}
@@ -3120,6 +3129,7 @@ mega_node* mega_session_put(mega_session* s, const gchar* remote_path, const gch
   gc_http_free http* h = http_new();
   http_set_content_type(h, "application/octet-stream");
   http_set_progress_callback(h, (http_progress_fn)progress_generic, s);
+  http_set_speed(h, s->max_ul, s->max_dl);
   gc_string_free GString* up_handle = http_post_stream_upload(h, p_url, file_size, (http_data_fn)put_process_data, &data, &local_err);
 
   if (!up_handle)
@@ -3339,6 +3349,7 @@ gboolean mega_session_get(mega_session* s, const gchar* local_path, const gchar*
   // perform download
   h = http_new();
   http_set_progress_callback(h, (http_progress_fn)progress_generic, s);
+  http_set_speed(h, s->max_ul, s->max_dl);
   if (!http_post_stream_download(h, url, (http_data_fn)get_process_data, &data, &local_err))
   {
     g_propagate_prefixed_error(err, local_err, "Data download failed: ");
@@ -3572,6 +3583,7 @@ gboolean mega_session_dl(mega_session* s, const gchar* handle, const gchar* key,
   // perform download
   h = http_new();
   http_set_progress_callback(h, (http_progress_fn)progress_generic, s);
+  http_set_speed(h, s->max_ul, s->max_dl);
   if (!http_post_stream_download(h, url, (http_data_fn)dl_process_data, &data, &local_err))
   {
     g_propagate_prefixed_error(err, local_err, "Data download failed: ");

--- a/lib/mega.c
+++ b/lib/mega.c
@@ -1936,7 +1936,7 @@ GQuark mega_error_quark(void)
 
 // {{{ mega_session_new
 
-mega_session* mega_session_new()
+mega_session* mega_session_new(void)
 {
   mega_session* s = g_new0(mega_session, 1);
 

--- a/lib/mega.h
+++ b/lib/mega.h
@@ -143,6 +143,8 @@ GQuark              mega_error_quark                (void);
 mega_session*       mega_session_new                (void);
 void                mega_session_free               (mega_session* s);
 
+void                mega_session_set_speed          (mega_session* s, gint ul, gint dl);
+
 void                mega_session_watch_status       (mega_session* s, mega_status_callback cb, gpointer userdata);
 void                mega_session_enable_previews    (mega_session* s, gboolean enable);
 

--- a/lib/tools.c
+++ b/lib/tools.c
@@ -50,6 +50,9 @@ static gboolean opt_no_config;
 static gboolean opt_no_ask_password;
 static gboolean opt_disable_previews;
 gboolean tool_allow_unknown_options = FALSE;
+static gint opt_speed_limit = 0;
+static gint opt_max_ul = 0;
+static gint opt_max_dl = 0;
 
 static gboolean opt_debug_callback(const gchar *option_name, const gchar *value, gpointer data, GError **error)
 {
@@ -94,6 +97,12 @@ static GOptionEntry auth_options[] =
   { "no-ask-password",    '\0',  0, G_OPTION_ARG_NONE,      &opt_no_ask_password,  "Never ask interactively for a password",      NULL       },
   { "disable-previews",   '\0',  0, G_OPTION_ARG_NONE,      &opt_disable_previews, "Never generate previews when uploading file", NULL       },
   { "reload",             '\0',  0, G_OPTION_ARG_NONE,      &opt_reload_files,     "Reload filesystem cache",                     NULL       },
+  { NULL }
+};
+
+static GOptionEntry network_options[] =
+{
+  { "limit-speed",              's',  0, G_OPTION_ARG_INT, &opt_speed_limit, "Limit transfer speed (KB/s)",  "KBPS"  },
   { NULL }
 };
 
@@ -381,6 +390,7 @@ void tool_init(gint* ac, gchar*** av, const gchar* tool_name, GOptionEntry* tool
     g_option_context_add_main_entries(opt_context, tool_entries, NULL);
   g_option_context_add_main_entries(opt_context, auth_options, NULL);
   g_option_context_add_main_entries(opt_context, basic_options, NULL);
+  g_option_context_add_main_entries(opt_context, network_options, NULL);
 
   if (!g_option_context_parse(opt_context, ac, av, &local_err))
   {
@@ -391,7 +401,6 @@ void tool_init(gint* ac, gchar*** av, const gchar* tool_name, GOptionEntry* tool
 
   print_version();
 
-  // load username/password from ini file
   if (!opt_no_config || opt_config)
   {
     gboolean status;
@@ -411,16 +420,33 @@ void tool_init(gint* ac, gchar*** av, const gchar* tool_name, GOptionEntry* tool
 
     if (status)
     {
+      // load username/password from ini file
       if (!opt_username)
         opt_username = g_key_file_get_string(kf, "Login", "Username", NULL);
       if(!opt_password)
         opt_password = g_key_file_get_string(kf, "Login", "Password", NULL);
-
       gint to = g_key_file_get_integer(kf, "Cache", "Timeout", &local_err);
       if (local_err == NULL)
         opt_cache_timout = to;
       else
         g_clear_error(&local_err);
+      
+
+      // Load speed limits from settings file
+      if (opt_speed_limit == 0)
+      {
+        gint ul = g_key_file_get_integer(kf, "Network", "UploadSpeedLimit", NULL);
+        if (local_err == NULL)
+          opt_max_ul = ul;
+        else
+          g_clear_error(&local_err);
+
+        gint dl = g_key_file_get_integer(kf, "Network", "DownloadSpeedLimit", NULL);
+        if (local_err == NULL)
+          opt_max_dl = dl;
+        else
+          g_clear_error(&local_err);
+      }
     }
   }
 
@@ -436,8 +462,20 @@ void tool_init(gint* ac, gchar*** av, const gchar* tool_name, GOptionEntry* tool
     exit(1);
   }
 
+  if (opt_speed_limit < 0)
+  {
+    g_printerr("ERROR: You must specify a valid speed limit\n");
+    exit(1);
+  }
+
   if (!opt_password)
     opt_password = input_password();
+
+  if (opt_max_ul == 0 && opt_max_dl == 0) {
+    // Default to whichever speed limit was specified over commandline
+    opt_max_ul = opt_speed_limit;
+    opt_max_dl = opt_speed_limit;
+  }
 }
 
 mega_session* tool_start_session(void)
@@ -447,6 +485,7 @@ mega_session* tool_start_session(void)
   gboolean loaded = FALSE;
 
   mega_session* s = mega_session_new();
+  mega_session_set_speed(s, opt_max_ul, opt_max_dl);
 
   // try to load cached session data (they are valid for 10 minutes since last
   // user_get or refresh)

--- a/lib/tools.c
+++ b/lib/tools.c
@@ -435,17 +435,23 @@ void tool_init(gint* ac, gchar*** av, const gchar* tool_name, GOptionEntry* tool
       // Load speed limits from settings file
       if (opt_speed_limit == 0)
       {
-        gint ul = g_key_file_get_integer(kf, "Network", "UploadSpeedLimit", NULL);
+        gint ul = g_key_file_get_integer(kf, "Network", "UploadSpeedLimit", &local_err);
         if (local_err == NULL)
           opt_max_ul = ul;
         else
+        {
+          g_printerr("WARNING: Invalid upload speed limit set on config file: %s\n", local_err->message);
           g_clear_error(&local_err);
+        }
 
-        gint dl = g_key_file_get_integer(kf, "Network", "DownloadSpeedLimit", NULL);
+        gint dl = g_key_file_get_integer(kf, "Network", "DownloadSpeedLimit", &local_err);
         if (local_err == NULL)
           opt_max_dl = dl;
         else
+        {
+          g_printerr("WARNING: Invalid download speed limit set on config file: %s\n", local_err->message);
           g_clear_error(&local_err);
+        }
       }
     }
   }

--- a/tools/dl.c
+++ b/tools/dl.c
@@ -27,12 +27,14 @@ static gchar* opt_path = ".";
 static gboolean opt_stream = FALSE;
 static gboolean opt_noprogress = FALSE;
 static gboolean opt_print_names = FALSE;
+static gint opt_speed_limit = 0;
 
 static GOptionEntry entries[] =
 {
   { "path",          '\0',   0, G_OPTION_ARG_FILENAME,  &opt_path,  "Local directory or file name, to save data to",  "PATH" },
   { "no-progress",   '\0',   0, G_OPTION_ARG_NONE,    &opt_noprogress,  "Disable progress bar",   NULL},
   { "print-names",   '\0',   0, G_OPTION_ARG_NONE,    &opt_print_names,  "Print names of downloaded files",   NULL},
+  { "limit-speed",        's',   0, G_OPTION_ARG_INT, &opt_speed_limit, "Limit download speed (KB/s)",  "KBPS"  },
   { NULL }
 };
 
@@ -171,6 +173,12 @@ int main(int ac, char* av[])
     return 1;
   }
 
+  if (opt_speed_limit < 0)
+  {
+    g_printerr("ERROR: You must specify a valid speed limit\n");
+    exit(1);
+  }
+
   // prepare link parsers
 
   file_regex = g_regex_new("^https?://mega(?:\\.co)?\\.nz/#!([a-z0-9_-]{8})!([a-z0-9_-]{43})$", G_REGEX_CASELESS, 0, NULL);
@@ -182,6 +190,7 @@ int main(int ac, char* av[])
   // create session
 
   s = mega_session_new();
+  mega_session_set_speed(s, 0, opt_speed_limit);
 
   mega_session_watch_status(s, status_callback, NULL);
 


### PR DESCRIPTION
Here is my initial implementation for speed controls (as per #36)

So far it does the job:

- Implemented --limit-speed/-s, which will set both UL/DL speeds. Since tools do only one operation at a time, it means that whichever speed you specify will be used for the operation you're going to do
- Also implemented inifile options UploadSpeedLimit and DownloadSpeedLimit, for those that need more finegrained control over their UL/DL speeds (say: you always use the same account and know the limits for your specific connection). Of course, --limit-speed will override them!

There is room for improvement, though:

- For tools using tool_init, it propagates the --limit-speed switch, even if they don't need it! (megals/megarm/megadf/etc.). Maybe there should be a better way to deal with this - either a separate init procedure, or moving the speedlimit commandline parsing to each tool that needs it (ugh)
- I've created a separate network_options GOptionEntry aimed at network settings. So far, limit-speed is feeling alone there. Anyone willing to do proxy support?

(yay, my first pull request ever~!)