### PR TITLE
Fix compiling against libressl

### DIFF
--- a/lib/mega.c
+++ b/lib/mega.c
@@ -803,7 +803,7 @@ static gboolean rsa_key_gen(rsa_key* k)
     return FALSE;
   }
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x101000000L && !defined(LIBRESSL_VERSION_NUMBER)
   RSA_get0_key(key, &k->m, &k->e, &k->d);
   RSA_get0_factors(key, &k->q, &k->p);
   RSA_get0_crt_params(key, NULL, NULL, &k->u);


### PR DESCRIPTION
For libressl users it will cause a compiling error. This should be all that is needed.