### PR TITLE
Partial / resume download support

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -376,7 +376,7 @@ again:
   return res;
 }
 
-gboolean http_post_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, GError** err, gint64 file_size, goffset resume_from)
+gboolean http_get_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, GError** err, gint64 file_size, goffset resume_from)
 {
   struct curl_slist* headers = NULL;
   glong http_status = 0;

--- a/lib/http.c
+++ b/lib/http.c
@@ -393,16 +393,12 @@ gboolean http_get_stream_download(http* h, const gchar* url, http_data_fn write_
 
   http_no_expect(h);
 
-  // first get length of string to allocate memory
-  // source: http://stackoverflow.com/a/32819876/2193236
-  gsize len = snprintf(NULL, 0, "%lu-%lu", resume_from, file_size);
-  range = g_try_malloc(len + 1);
+  range = g_strdup_printf("%lu-%lu", resume_from, file_size);
   if (!range)
   {
     g_set_error(err, HTTP_ERROR, HTTP_ERROR_OTHER, "Memory allocation failed");
     goto out;
   }
-  snprintf(range, len + 1, "%lu-%lu", resume_from, file_size);
 
   // GET request instead of POST
   // setup post headers and url

--- a/lib/http.c
+++ b/lib/http.c
@@ -376,7 +376,7 @@ again:
   return res;
 }
 
-gboolean http_get_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, GError** err, gint64 file_size, goffset resume_from)
+gboolean http_get_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, gint64 file_size, goffset resume_from, GError** err)
 {
   struct curl_slist* headers = NULL;
   glong http_status = 0;
@@ -387,9 +387,9 @@ gboolean http_get_stream_download(http* h, const gchar* url, http_data_fn write_
 
   g_return_val_if_fail(h != NULL, FALSE);
   g_return_val_if_fail(url != NULL, FALSE);
-  g_return_val_if_fail(err == NULL || *err == NULL, FALSE);
   g_return_val_if_fail(file_size > 0, FALSE);
   g_return_val_if_fail(resume_from >= 0, FALSE);
+  g_return_val_if_fail(err == NULL || *err == NULL, FALSE);
 
   http_no_expect(h);
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -406,7 +406,8 @@ gboolean http_get_stream_download(http* h, const gchar* url, http_data_fn write_
   curl_easy_setopt(h->curl, CURLOPT_URL, url);
 
   // set range to download
-  curl_easy_setopt(h->curl, CURLOPT_RANGE, range);
+  if (resume_from > 0)
+    curl_easy_setopt(h->curl, CURLOPT_RANGE, range);
 
   // setup response writer
   data.cb = write_cb;

--- a/lib/http.h
+++ b/lib/http.h
@@ -52,7 +52,7 @@ void http_set_proxy(http* h, const gchar* proxy);
 
 GString* http_post(http* h, const gchar* url, const gchar* body, gssize body_len, GError** err);
 GString* http_post_stream_upload(http* h, const gchar* url, goffset len, http_data_fn read_cb, gpointer user_data, GError** err);
-gboolean http_post_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, GError** err, gint64 file_size, goffset resume_from);
+gboolean http_get_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, GError** err, gint64 file_size, goffset resume_from);
 
 void http_free(http* h);
 

--- a/lib/http.h
+++ b/lib/http.h
@@ -52,7 +52,7 @@ void http_set_proxy(http* h, const gchar* proxy);
 
 GString* http_post(http* h, const gchar* url, const gchar* body, gssize body_len, GError** err);
 GString* http_post_stream_upload(http* h, const gchar* url, goffset len, http_data_fn read_cb, gpointer user_data, GError** err);
-gboolean http_get_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, GError** err, gint64 file_size, goffset resume_from);
+gboolean http_get_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, gint64 file_size, goffset resume_from, GError** err);
 
 void http_free(http* h);
 

--- a/lib/http.h
+++ b/lib/http.h
@@ -52,7 +52,7 @@ void http_set_proxy(http* h, const gchar* proxy);
 
 GString* http_post(http* h, const gchar* url, const gchar* body, gssize body_len, GError** err);
 GString* http_post_stream_upload(http* h, const gchar* url, goffset len, http_data_fn read_cb, gpointer user_data, GError** err);
-gboolean http_post_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, GError** err);
+gboolean http_post_stream_download(http* h, const gchar* url, http_data_fn write_cb, gpointer user_data, GError** err, gint64 file_size, goffset resume_from);
 
 void http_free(http* h);
 

--- a/lib/mega.c
+++ b/lib/mega.c
@@ -3322,10 +3322,10 @@ static gboolean partial_get_verify_data(GFile* file, gsize size, struct _get_dat
     return FALSE;
   }
 
-  if (size > data->buffer->len)
+  if (CHUNK_SIZE > data->buffer->len)
   {
-    g_byte_array_set_size(buffer, size);
-    g_byte_array_set_size(data->buffer, size);
+    g_byte_array_set_size(buffer, CHUNK_SIZE);
+    g_byte_array_set_size(data->buffer, CHUNK_SIZE);
   }
 
   while (total_read < size)
@@ -3596,10 +3596,10 @@ static gboolean partial_dl_verify_data(GFile* file, gsize size, struct _dl_data*
     return FALSE;
   }
 
-  if (size > data->buffer->len)
+  if (CHUNK_SIZE > data->buffer->len)
   {
-    g_byte_array_set_size(buffer, size);
-    g_byte_array_set_size(data->buffer, size);
+    g_byte_array_set_size(buffer, CHUNK_SIZE);
+    g_byte_array_set_size(data->buffer, CHUNK_SIZE);
   }
 
   while (total_read < size)

--- a/lib/mega.c
+++ b/lib/mega.c
@@ -1631,7 +1631,10 @@ static gboolean get_partial_file_offset(GFile* file, goffset* resume_from, GErro
 
   // if file is not found => no partial file, suppress error
   if (g_error_matches(*err, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+  {
+    g_clear_error(err);
     return FALSE;
+  }
 
   if (!info)
   {
@@ -3322,7 +3325,7 @@ static gboolean partial_get_verify_data(GFile* file, gsize size, struct _get_dat
     return FALSE;
   }
 
-  if (CHUNK_SIZE > data->buffer->len)
+  if (CHUNK_SIZE > data->buffer->len || CHUNK_SIZE > buffer->len)
   {
     g_byte_array_set_size(buffer, CHUNK_SIZE);
     g_byte_array_set_size(data->buffer, CHUNK_SIZE);
@@ -3611,7 +3614,7 @@ static gboolean partial_dl_verify_data(GFile* file, gsize size, struct _dl_data*
     return FALSE;
   }
 
-  if (CHUNK_SIZE > data->buffer->len)
+  if (CHUNK_SIZE > data->buffer->len || CHUNK_SIZE > buffer->len)
   {
     g_byte_array_set_size(buffer, CHUNK_SIZE);
     g_byte_array_set_size(data->buffer, CHUNK_SIZE);

--- a/lib/mega.c
+++ b/lib/mega.c
@@ -3679,7 +3679,8 @@ gboolean mega_session_dl(mega_session* s, const gchar* handle, const gchar* key,
 
       if (g_file_query_file_type(parent_dir, 0, NULL) != G_FILE_TYPE_DIRECTORY)
       {
-        g_set_error(err, MEGA_ERROR, MEGA_ERROR_OTHER, "Can't download file into: %s", g_file_get_path(parent_dir));
+        gc_free gchar* path = g_file_get_path(parent_dir);
+        g_set_error(err, MEGA_ERROR, MEGA_ERROR_OTHER, "Can't download file into: %s", path);
         return FALSE;
       }
     }

--- a/lib/mega.c
+++ b/lib/mega.c
@@ -1629,6 +1629,10 @@ static gboolean get_partial_file_offset(GFile* file, goffset* resume_from, GErro
 {
   gc_object_unref GFileInfo* info = g_file_query_info(file, G_FILE_ATTRIBUTE_STANDARD_SIZE, G_FILE_QUERY_INFO_NONE, NULL, err);
 
+  // if file is not found => no partial file, suppress error
+  if (g_error_matches(*err, G_IO_ERROR, G_IO_ERROR_NOT_FOUND))
+    return FALSE;
+
   if (!info)
   {
     *resume_from = -1;

--- a/lib/mega.c
+++ b/lib/mega.c
@@ -1644,13 +1644,8 @@ static gboolean get_partial_file_offset(GFile* file, goffset* resume_from, GErro
   }
 
   *resume_from = g_file_info_get_size(info);
-  if (*resume_from == 0)
-    return FALSE;
-  else
-  {
-    g_info("partial file detected, size: %lu bytes", *resume_from);
-    return TRUE;
-  }
+  g_info("partial file detected, size: %lu bytes", *resume_from);
+  return TRUE;
 }
 
 // }}}

--- a/lib/mega.c
+++ b/lib/mega.c
@@ -1625,9 +1625,16 @@ static gchar* path_simplify(const gchar* path)
 
 // {{{
 
-static gboolean get_partial_file_offset(GFile* file, goffset* resume_from)
+static gboolean get_partial_file_offset(GFile* file, goffset* resume_from, GError** err)
 {
-  gc_object_unref GFileInfo* info = g_file_query_info(file, G_FILE_ATTRIBUTE_STANDARD_SIZE, G_FILE_QUERY_INFO_NONE, NULL, NULL);
+  gc_object_unref GFileInfo* info = g_file_query_info(file, G_FILE_ATTRIBUTE_STANDARD_SIZE, G_FILE_QUERY_INFO_NONE, NULL, err);
+
+  if (!info)
+  {
+    *resume_from = -1;
+    g_set_error(err, MEGA_ERROR, MEGA_ERROR_OTHER, "Can't query file info");
+    return FALSE;
+  }
 
   *resume_from = g_file_info_get_size(info);
   if (*resume_from == 0)
@@ -3378,18 +3385,21 @@ gboolean mega_session_get(mega_session* s, const gchar* local_path, const gchar*
         GFile *child = g_file_get_child(file, n->name);
 
         if (g_file_query_exists(child, NULL))
-          partial_file = get_partial_file_offset(child, &resume_from);
-        else
         {
-          printf("child does not exist");
-          partial_file = FALSE;
+          partial_file = get_partial_file_offset(child, &resume_from, err);
+          if (resume_from == -1)
+            goto err;
         }
+        else
+          partial_file = FALSE;
 
         file = child;
       }
       else
       {
-        partial_file = get_partial_file_offset(file, &resume_from);
+        partial_file = get_partial_file_offset(file, &resume_from, err);
+        if (resume_from == -1)
+          goto err;
       }
     }
 
@@ -3471,7 +3481,7 @@ gboolean mega_session_get(mega_session* s, const gchar* local_path, const gchar*
   http_set_progress_callback(h, (http_progress_fn)progress_generic, s);
   http_set_speed(h, s->max_ul, s->max_dl);
   http_set_proxy(h, s->proxy);
-  if (!http_post_stream_download(h, url, (http_data_fn)get_process_data, &data, &local_err, file_size, resume_from))
+  if (!http_get_stream_download(h, url, (http_data_fn)get_process_data, &data, &local_err, file_size, resume_from))
   {
     g_propagate_prefixed_error(err, local_err, "Data download failed: ");
     goto err;
@@ -3631,7 +3641,9 @@ gboolean mega_session_dl(mega_session* s, const gchar* handle, const gchar* key,
 
       if (file_type != G_FILE_TYPE_DIRECTORY)
       {
-        partial_file = get_partial_file_offset(file, &resume_from);
+        partial_file = get_partial_file_offset(file, &resume_from, err);
+        if (resume_from == -1)
+          goto err;
       }
       else
       {
@@ -3737,13 +3749,15 @@ gboolean mega_session_dl(mega_session* s, const gchar* handle, const gchar* key,
       file = g_file_get_child(parent_dir, node_name);
 
       // check if file is partially downloaded
-      partial_file = get_partial_file_offset(file, &resume_from);
+      partial_file = get_partial_file_offset(file, &resume_from, err);
+      if (resume_from == -1)
+        goto err;
     }
 
     // sanity check partial download conditions
     if (resume_from == file_size)
     {
-      g_set_error(err, MEGA_ERROR, MEGA_ERROR_OTHER, "File already exists: %s", local_path);
+      g_set_error(err, MEGA_ERROR, MEGA_ERROR_OTHER, "File already exists: %s", g_file_get_path(file));
       return FALSE;
     }
     else if (resume_from > file_size)
@@ -3758,7 +3772,7 @@ gboolean mega_session_dl(mega_session* s, const gchar* handle, const gchar* key,
     if (partial_file)
     {
       // open file for appending to it
-      data.stream = stream = g_file_append_to(file, resume_from, NULL, &local_err);
+      data.stream = stream = g_file_append_to(file, 0, NULL, &local_err);
       g_debug("%s", "appending to partial file");
     }
     else
@@ -3806,7 +3820,7 @@ gboolean mega_session_dl(mega_session* s, const gchar* handle, const gchar* key,
   http_set_progress_callback(h, (http_progress_fn)progress_generic, s);
   http_set_speed(h, s->max_ul, s->max_dl);
   http_set_proxy(h, s->proxy);
-  if (!http_post_stream_download(h, url, (http_data_fn)dl_process_data, &data, &local_err, file_size, resume_from))
+  if (!http_get_stream_download(h, url, (http_data_fn)dl_process_data, &data, &local_err, file_size, resume_from))
   {
     g_propagate_prefixed_error(err, local_err, "Data download failed: ");
     goto err;

--- a/lib/mega.c
+++ b/lib/mega.c
@@ -3365,7 +3365,6 @@ gboolean mega_session_get(mega_session* s, const gchar* local_path, const gchar*
   gc_free gchar* get_node = NULL, *url = NULL, *orig_fname = NULL;
   gc_http_free http* h = NULL;
   gc_byte_array_unref GByteArray* buffer = NULL;
-  gboolean remove_file = FALSE;
   gboolean partial_file = FALSE;
   goffset resume_from = 0;
 
@@ -3451,8 +3450,6 @@ gboolean mega_session_get(mega_session* s, const gchar* local_path, const gchar*
     }
   }
 
-  remove_file = TRUE;
-
   // initialize decrytpion key/state
   guchar aes_key[16], meta_mac_xor[8];
   unpack_node_key(n->key, aes_key, data.iv, meta_mac_xor);
@@ -3484,8 +3481,6 @@ gboolean mega_session_get(mega_session* s, const gchar* local_path, const gchar*
   // sanity check partial download conditions
   if (resume_from >= file_size)
   {
-    // do not remove file in case of this error
-    remove_file = FALSE;
     gc_free gchar* path = g_file_get_path(file);
     g_set_error(err, MEGA_ERROR, MEGA_ERROR_OTHER, "Potential overwrite of file with same name: '%s'", path);
     goto err;
@@ -3540,9 +3535,6 @@ gboolean mega_session_get(mega_session* s, const gchar* local_path, const gchar*
   return TRUE;
 
 err:
-  if (file && remove_file)
-    g_file_delete(file, NULL, NULL);
-
   return FALSE;
 }
 
@@ -3663,7 +3655,6 @@ gboolean mega_session_dl(mega_session* s, const gchar* handle, const gchar* key,
   gc_http_free http* h = NULL;
   gc_object_unref GFileOutputStream* stream = NULL;
   gc_byte_array_unref GByteArray* buffer = NULL;
-  gboolean remove_file = FALSE;
   gboolean partial_file = FALSE;
   goffset resume_from = 0;
 
@@ -3848,8 +3839,6 @@ gboolean mega_session_dl(mega_session* s, const gchar* handle, const gchar* key,
     }
   }
 
-  remove_file = TRUE;
-
   // initialize decryption and mac calculation
   AES_set_encrypt_key(aes_key, 128, &data.k);
   chunked_cbc_mac_init8(&data.mac, aes_key, data.iv);
@@ -3903,9 +3892,6 @@ gboolean mega_session_dl(mega_session* s, const gchar* handle, const gchar* key,
   return TRUE;
 
 err:
-  if (file && remove_file)
-      g_file_delete(file, NULL, NULL);
-
   return FALSE;
 }
 

--- a/lib/mega.c
+++ b/lib/mega.c
@@ -3461,7 +3461,8 @@ gboolean mega_session_get(mega_session* s, const gchar* local_path, const gchar*
   // sanity check partial download conditions
   if (resume_from == file_size)
   {
-    g_set_error(err, MEGA_ERROR, MEGA_ERROR_OTHER, "File already exists: %s", g_file_get_path(file));
+    gc_free gchar* path = g_file_get_path(file);
+    g_set_error(err, MEGA_ERROR, MEGA_ERROR_OTHER, "File already exists: %s", path);
     return FALSE;
   }
   else if (resume_from > file_size)
@@ -3768,7 +3769,8 @@ gboolean mega_session_dl(mega_session* s, const gchar* handle, const gchar* key,
     // sanity check partial download conditions
     if (resume_from == file_size)
     {
-      g_set_error(err, MEGA_ERROR, MEGA_ERROR_OTHER, "File already exists: %s", g_file_get_path(file));
+      gc_free gchar* path = g_file_get_path(file);
+      g_set_error(err, MEGA_ERROR, MEGA_ERROR_OTHER, "File already exists: %s", path);
       return FALSE;
     }
     else if (resume_from > file_size)

--- a/lib/mega.c
+++ b/lib/mega.c
@@ -3505,7 +3505,7 @@ gboolean mega_session_get(mega_session* s, const gchar* local_path, const gchar*
   http_set_progress_callback(h, (http_progress_fn)progress_generic, s);
   http_set_speed(h, s->max_ul, s->max_dl);
   http_set_proxy(h, s->proxy);
-  if (!http_get_stream_download(h, url, (http_data_fn)get_process_data, &data, &local_err, file_size, resume_from))
+  if (!http_get_stream_download(h, url, (http_data_fn)get_process_data, &data, file_size, resume_from, &local_err))
   {
     g_propagate_prefixed_error(err, local_err, "Data download failed: ");
     goto err;
@@ -3868,7 +3868,7 @@ gboolean mega_session_dl(mega_session* s, const gchar* handle, const gchar* key,
   http_set_progress_callback(h, (http_progress_fn)progress_generic, s);
   http_set_speed(h, s->max_ul, s->max_dl);
   http_set_proxy(h, s->proxy);
-  if (!http_get_stream_download(h, url, (http_data_fn)dl_process_data, &data, &local_err, file_size, resume_from))
+  if (!http_get_stream_download(h, url, (http_data_fn)dl_process_data, &data, file_size, resume_from, &local_err))
   {
     g_propagate_prefixed_error(err, local_err, "Data download failed: ");
     goto err;


### PR DESCRIPTION
Implements #199, #7, #23 

This **only** includes partial / resume download support for `megadl` and `megaget`. Please let me know if there is anything you would like me to change. I am happy to discuss the code and the changes I've made.

Sidenote:
Upload support is much trickier to get working. Does MEGA support partial files as nodes? If so, then it is possible to query for the node, get the current size of the file, then use that size as the offset for the local file to upload the remaining bytes. The state (MAC, keys, etc.) can be saved in a temporary file somewhere locally. If MEGA does not, then I'm not sure there is a way to support partial uploads. 