### PR TITLE
Fix argument exclusion checks in megadf

### DIFF
--- a/tools/df.c
+++ b/tools/df.c
@@ -63,7 +63,7 @@ int main(int ac, char* av[])
     opts_used += opt_free ? 1 : 0;
     opts_used += opt_used ? 1 : 0;
 
-    if (opt_used > 1)
+    if (opts_used > 1)
     {
       g_printerr("ERROR: Options conflict, you should use either --total, --used, or --free.\n");
       return 1;
@@ -77,7 +77,7 @@ int main(int ac, char* av[])
     opts_used += opt_mb ? 1 : 0;
     opts_used += opt_gb ? 1 : 0;
 
-    if (opt_used > 1)
+    if (opts_used > 1)
     {
       g_printerr("ERROR: Options conflict, you should use either --human, --mb, or --gb.\n");
       return 1;


### PR DESCRIPTION
[clang-analyzer](http://clang-analyzer.llvm.org/)'s `scan-build` tool indicated that `opts_used` is incremented but never used. This patch fixes that issue.

Before fix:

```
$ ./megadf -u email@example.com -h --mb
Enter password for (email@example.com): 
Good, signing in...
Total: XX.X GiB
Used:  XX.X GiB
Free:  XX.X GiB
$ ./megadf -u email@example.com --total --free
Enter password for (email@example.com): 
Good, signing in...
XXXXXXXXXXX
```

After fix:

```
$ ./megadf -u email@example.com -h --mb
Enter password for (email@example.com): 
Good, signing in...
ERROR: Options conflict, you should use either --human, --mb, or --gb.
$ ./megadf -u email@example.com --total --free
Enter password for (email@example.com): 
Good, signing in...
ERROR: Options conflict, you should use either --total, --used, or --free.
```