### PR TITLE
Correct name of FreeBSD ports collection

### DIFF
--- a/README
+++ b/README
@@ -113,7 +113,7 @@ Be sure to check your distribution's package repository first.
 Installation on FreeBSD
 =======================
 
-Megatools is available in freshports thanks to Maxim V. Kostikov:
+Megatools is available in ports thanks to Maxim V. Kostikov:
 
   http://www.freshports.org/net/megatools/
 


### PR DESCRIPTION
Freshports is a site that tracks the state of the FreeBSD ports collection. Refer to the FreeBSD ports collection as "ports".