### PR TITLE
Don't immediately fail on invalid filename

### DIFF
--- a/lib/mega.c
+++ b/lib/mega.c
@@ -1984,12 +1984,16 @@ static struct mega_node *mega_node_parse(struct mega_session *s, const gchar *no
 		return NULL;
 	}
 
-	// check for invalid characters in the name
+	// replace invalid filename characters with whitespace
+	gchar *check;
 #ifdef G_OS_WIN32
-	if (strpbrk(node_name, "/\\<>:\"|?*") || !strcmp(node_name, ".") || !strcmp(node_name, ".."))
+	while (check = strpbrk(node_name, "/\\<>:\"|?*"))
 #else
-	if (strpbrk(node_name, "/") || !strcmp(node_name, ".") || !strcmp(node_name, ".."))
+	while (check = strpbrk(node_name, "/"))
 #endif
+			*check = ' ';
+	// check for invalid names
+	if (!strcmp(node_name, ".") || !strcmp(node_name, ".."))
 	{
 		g_printerr("WARNING: Skipping FS node %s because it's name is invalid '%s'\n", node_h, node_name);
 		return NULL;
@@ -4667,12 +4671,16 @@ gboolean mega_session_dl_prepare(struct mega_session *s, struct mega_download_da
 		return FALSE;
 	}
 
-	// check for invalid characters in filename
+	// replace invalid filename characters with whitespace
+	gchar *check;
 #ifdef G_OS_WIN32
-	if (strpbrk(node_name, "/\\<>:\"|?*") || !strcmp(node_name, ".") || !strcmp(node_name, ".."))
+	while (check = strpbrk(node_name, "/\\<>:\"|?*"))
 #else
-	if (strpbrk(node_name, "/") || !strcmp(node_name, ".") || !strcmp(node_name, ".."))
+	while (check = strpbrk(node_name, "/"))
 #endif
+			*check = ' ';
+	// check for invalid names
+	if (!strcmp(node_name, ".") || !strcmp(node_name, ".."))
 	{
 		g_set_error(err, MEGA_ERROR, MEGA_ERROR_OTHER, "Remote file name is invalid: '%s'", node_name);
 		return FALSE;


### PR DESCRIPTION
Test URLs:
https://mega.nz/#F!B1chhKYZ!50sRlF1mogf0gGyeB62B_A
https://mega.nz/#!AwNhlaRL!TswpsTVSopPEvML9E_odtnyOWgTshIAlOfLPfOe46i8
There is currently no way to download files/folders with '/' (or "/\\<>:\"|?*" on windows) in their names using megadl.
The patch replaces all invalid characters with ' ' to allow for downloading instead of outright failing.